### PR TITLE
Add activerecord-cause.rb

### DIFF
--- a/lib/activerecord-cause.rb
+++ b/lib/activerecord-cause.rb
@@ -1,0 +1,1 @@
+require "activerecord/cause"


### PR DESCRIPTION
I want to use like this :kissing_heart:

``` ruby
require "activerecord-cause"
```
