### PR TITLE
Fix. can not run `rake spec:all` and `rake bundle_update:all`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :default => :spec
 
 pwd = File.expand_path('../', __FILE__)
 
-gemfiles = %w(activerecord-40 activerecord-41 activerecord-42 activerecord-50)
+gemfiles = %w(activerecord-41 activerecord-42 activerecord-50)
 
 namespace :spec do
   gemfiles.each do |gemfile|


### PR DESCRIPTION
`activerecord-40.gemfile` was removed at de6477473dce5fe3b5ffb1bcc3f18326977644ca 

``` sh
$ bundle exec rake bundle_update:all
BUNDLE_GEMFILE='/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/gemfiles/activerecord-40.gemfile' bundle update
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/gemfiles/activerecord-40.gemfile not found
rake aborted!
Command failed with status (10): [BUNDLE_GEMFILE='/Users/sueyoshi_go/workspa...]
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/Rakefile:36:in `block (4 levels) in <top (required)>'
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/Rakefile:35:in `block (3 levels) in <top (required)>'
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/Rakefile:44:in `block (3 levels) in <top (required)>'
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/Rakefile:43:in `each'
/Users/sueyoshi_go/workspace/github.com/joker1007/activerecord-cause/Rakefile:43:in `block (2 levels) in <top (required)>'
/Users/sueyoshi_go/.rbenv/versions/2.3.1/bin/bundle:23:in `load'
/Users/sueyoshi_go/.rbenv/versions/2.3.1/bin/bundle:23:in `<main>'
Tasks: TOP => bundle_update:activerecord-40
(See full trace by running task with --trace)
```
