### PR TITLE
Fix log sql with query cache

### DIFF
--- a/lib/activerecord/cause.rb
+++ b/lib/activerecord/cause.rb
@@ -99,7 +99,8 @@ module ActiveRecord
 
           unless (payload[:binds] || []).empty?
             binds = if ActiveRecord.version >= Gem::Version.new("5.0.3")
-                      "  " + payload[:binds].zip(payload[:type_casted_binds]).map { |attr, value| render_bind(attr, value) }.inspect
+                      casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
+                      "  " + payload[:binds].zip(casted_params).map { |attr, value| render_bind(attr, value) }.inspect
                     else
                       "  " + payload[:binds].map { |attr| render_bind(attr) }.inspect
                     end


### PR DESCRIPTION
When log sql event caused by load from cache, `event.payload[:type_casted_binds]` is nil.
`ActiveRecord#LogSubscriber#type_casted_binds` care this case.

- https://github.com/rails/rails/blob/v5.0.3/activerecord/lib/active_record/log_subscriber.rb#L36
- https://github.com/rails/rails/blob/v5.1.1/activerecord/lib/active_record/log_subscriber.rb#L32