### PR TITLE
support activerecord 7.1.1

### DIFF
--- a/lib/activerecord/cause.rb
+++ b/lib/activerecord/cause.rb
@@ -177,7 +177,7 @@ module ActiveRecord
       end
 
       def generate_cause(text, mode_option)
-        color(text. nil, bold: mode_option)
+        color(text, nil, bold: mode_option)
       end
     end
   end

--- a/lib/activerecord/cause.rb
+++ b/lib/activerecord/cause.rb
@@ -45,7 +45,7 @@ module ActiveRecord
 
           name = name_with_color(payload[:name])
           sql = sql_with_color(payload[:sql])
-          cause = color(loc.to_s, nil, true)
+          cause = generate_cause(loc.to_s, true)
 
           output =
             if ActiveRecord::Cause.log_with_sql
@@ -84,6 +84,10 @@ module ActiveRecord
 
       def sql_with_color(payload_sql)
         raise NotImplementedError
+      end
+
+      def generate_cause(text, mode_option)
+        color(text. nil, mode_option)
       end
     end
 
@@ -160,13 +164,31 @@ module ActiveRecord
         "  " + payload[:binds].zip(casted_params).map { |attr, value| render_bind(attr, value) }.inspect
       end
     end
+
+    class LogSubscriberAR712 < LogSubscriberAR515
+      def sql(event)
+        super
+      end
+
+      private
+
+      def sql_with_color(sql)
+        color(sql, sql_color(sql), bold: true)
+      end
+
+      def generate_cause(text, mode_option)
+        color(text. nil, bold: mode_option)
+      end
+    end
   end
 end
 
 require "activerecord/cause/railtie" if defined?(Rails)
 
 ActiveSupport.on_load(:active_record) do
-  if ActiveRecord.version >= Gem::Version.new("5.1.0")
+  if ActiveRecord.version >= Gem::Version.new("7.1.2")
+    ActiveRecord::Cause::LogSubscriberAR712.attach_to :active_record
+  elsif ActiveRecord.version >= Gem::Version.new("5.1.0")
     if ActiveRecord.version >= Gem::Version.new("5.1.5")
       ActiveRecord::Cause::LogSubscriberAR515.attach_to :active_record
     else

--- a/lib/activerecord/cause.rb
+++ b/lib/activerecord/cause.rb
@@ -165,7 +165,7 @@ module ActiveRecord
       end
     end
 
-    class LogSubscriberAR712 < LogSubscriberAR515
+    class LogSubscriberAR711 < LogSubscriberAR515
       def sql(event)
         super
       end
@@ -186,8 +186,8 @@ end
 require "activerecord/cause/railtie" if defined?(Rails)
 
 ActiveSupport.on_load(:active_record) do
-  if ActiveRecord.version >= Gem::Version.new("7.1.2")
-    ActiveRecord::Cause::LogSubscriberAR712.attach_to :active_record
+  if ActiveRecord.version >= Gem::Version.new("7.1.1")
+    ActiveRecord::Cause::LogSubscriberAR711.attach_to :active_record
   elsif ActiveRecord.version >= Gem::Version.new("5.1.0")
     if ActiveRecord.version >= Gem::Version.new("5.1.5")
       ActiveRecord::Cause::LogSubscriberAR515.attach_to :active_record

--- a/lib/activerecord/cause.rb
+++ b/lib/activerecord/cause.rb
@@ -87,7 +87,7 @@ module ActiveRecord
       end
 
       def generate_cause(text, mode_option)
-        color(text. nil, mode_option)
+        color(text, nil, mode_option)
       end
     end
 


### PR DESCRIPTION
Starting with Rails 7.1.1, passing a boolean as the last argument to the color method seems to trigger a warning.
https://github.com/rails/rails/blob/v7.1.1/activesupport/lib/active_support/log_subscriber.rb#L179-L182

I have fixed it.
